### PR TITLE
Adding new hvac_state property

### DIFF
--- a/nest/nest.py
+++ b/nest/nest.py
@@ -538,6 +538,10 @@ class Device(NestBase):
         return self._device['hot_water_temperature']
 
     @property
+    def hvac_state(self):
+        return self._device['hvac_state']
+
+    @property
     def eco(self):
         raise NotImplementedError("Deprecated Nest API")
         # eco_mode = self._device['eco']['mode']


### PR DESCRIPTION
Pulls the `hvac_state` property from the Nest API to indicate the current heating/cooling/off action (as opposed to the mode the device is set for). See https://developers.nest.com/documentation/api-reference/overview#hvacstate for details.